### PR TITLE
Rework URL replacement

### DIFF
--- a/app.js
+++ b/app.js
@@ -63,15 +63,7 @@ client.on(Events.MessageCreate, async function (message)
         let uri = URI(url);
         const domain = uri.domain();
 
-        // Remove tracking parameters
-        if (domain === 'twitter.com' || domain === 'x.com')
-        {
-            uri.removeQuery('t');
-        } 
-        else if (domain === 'youtube.com' || domain === 'youtu.be')
-        {
-            uri.removeQuery('si');
-        }
+        RemoveTrackingParameters(uri);
 
         // Replace domain with its embed-friendly version (if it has one)
         if (DOMAIN_MAPPING.hasOwnProperty(domain))
@@ -115,6 +107,36 @@ client.on(Events.MessageReactionAdd, (reaction, user) =>
         }
     }
 });
+
+/**
+ * Returns whether `domain` equals any of `matching_domains` (or their embed-friendly versions).
+ */
+function DomainMatches(domain, ...matching_domains)
+{
+    let matches = [];
+    for (const d of matching_domains)
+    {
+        matches.push(d, DOMAIN_MAPPING[d]);
+    }
+    return matches.includes(domain);
+}
+
+/**
+ * Strips tracking/fingerprinting query parameters from `uri`.
+ */
+function RemoveTrackingParameters(uri)
+{
+    const domain = uri.domain();
+
+    if (DomainMatches(domain, 'twitter.com', 'x.com'))
+    {
+        uri.removeQuery('t');
+    }
+    else if (DomainMatches(domain, 'youtube.com', 'youtu.be'))
+    {
+        uri.removeQuery('si');
+    }
+}
 
 function RepostMessage(message, name, messageText)
 {

--- a/app.js
+++ b/app.js
@@ -1,15 +1,26 @@
 require('dotenv').config();
 
 const { Client, Events, GatewayIntentBits } = require('discord.js');
+const URI = require('urijs');
 
 const DELETE_REACT = String.fromCharCode(0x274C);
-const TWITTER_ADDRESS_TO_CHANGE_TO = "fxtwitter.com";
-const REDDIT_ADDRESS_TO_CHANGE_TO = "rxddit.com";
-const TIKTOK_ADDRESS_TO_CHANGE_TO = "tnktok.com";
-const INSTAGRAM_ADDRESS_TO_CHANGE_TO = "instagramez.com";
-const PIXIV_ADDRESS_TO_CHANGE_TO = "phixiv.net";
-const BLUESKY_ADDRESS_TO_CHANGE_TO = "bskyx.app";
-const TUMBLR_ADDRESS_TO_CHANGE_TO = "tpmblr.com";
+
+// Maps a domain to its embed-friendly replacement.
+//
+// Note that a domain is only the TLD + 2LD (Top-Level Domain + 2nd-Level Domain).
+// E.g. in the URL "https://account.tumblr.com/my-account", the domain is "tumblr.com".
+// For more information:
+//      https://medialize.github.io/URI.js/about-uris.html#components
+const DOMAIN_MAPPING = {
+    'twitter.com': 'fxtwitter.com',
+    'x.com': 'fixupx.com',
+    'reddit.com': 'rxddit.com',
+    'tiktok.com': 'tnktok.com',
+    'instagram.com': 'instagramez.com',
+    'pixiv.net': 'phixiv.net',
+    'bsky.app': 'bskyx.app',
+    'tumblr.com': 'tpmblr.com'
+}
 
 const client = new Client
 (
@@ -36,67 +47,46 @@ client.on(Events.ClientReady, async () =>
 client.on(Events.MessageCreate, async function (message)
 {
     if (message.author.id === clientUserId)
-	{
+    {
         return;
     }
 
     let messageContent = message?.content ?? "";
-    let isTweet = false;
     let repostMessage = false;
 
-    // switch to vxtwitter
-    if (messageContent.match(/https:\/\/(www\.)?twitter\.com\//i) !== null)
-    {
-        messageContent = messageContent.replace('twitter.com', TWITTER_ADDRESS_TO_CHANGE_TO);
-        isTweet = true;
-        repostMessage = true;
-    } 
-    else if (messageContent.match(/https:\/\/(www\.)?x\.com\//i) !== null)
-    {
-        messageContent = messageContent.replace('x.com', TWITTER_ADDRESS_TO_CHANGE_TO);
-        isTweet = true;
-        repostMessage = true;
-    }
-    else if (messageContent.match(/https:\/\/(www\.)?reddit\.com\//i) !== null)
-    {
-        messageContent = messageContent.replace('reddit.com', REDDIT_ADDRESS_TO_CHANGE_TO);
-        repostMessage = true;
-    }
-    else if (messageContent.match(/https:\/\/(www\.)?(vm\.)?tiktok\.com\//i) !== null)
-    {
-        messageContent = messageContent.replace('tiktok.com', TIKTOK_ADDRESS_TO_CHANGE_TO);
-        repostMessage = true;
-    }
-    else if (messageContent.match(/https:\/\/(www\.)?instagram\.com\//i) !== null)
-    {
-        messageContent = messageContent.replace('instagram.com', INSTAGRAM_ADDRESS_TO_CHANGE_TO);
-        repostMessage = true;
-    }
-    else if (messageContent.match(/https:\/\/(www\.)?pixiv\.net\//i) !== null)
-    {
-        messageContent = messageContent.replace('pixiv.net', PIXIV_ADDRESS_TO_CHANGE_TO);
-        repostMessage = true;
-    }
-    else if (messageContent.match(/https:\/\/(www\.)?bsky\.app\//i) !== null)
-    {
-        messageContent = messageContent.replace('bsky.app', BLUESKY_ADDRESS_TO_CHANGE_TO);
-        repostMessage = true;
-    }
-    else if (messageContent.match(/https:\/\/(.)*(\.)?tumblr\.com\//i) !== null) // works with tumblr.com/account and account.tumblr.com
-    {
-        messageContent = messageContent.replace('tumblr.com', TUMBLR_ADDRESS_TO_CHANGE_TO);
-        repostMessage = true;
-    }
-
-    if (isTweet)
-    {
-        // strip tracking link
-        if (messageContent.match(/\?t=/gm) != null)
-        {
-            messageContent = messageContent.match(/.+?(?=\?t=)/gm)?.[0] ?? messageContent;
+    messageContent = URI.withinString(messageContent, function(url, start, end, source) {
+        // Don't do anything if the url is wrapped in Discord's non-embed syntax
+        if (source[start-1] === '<' && source[end] === '>') {
+            return url;
         }
-    }
-    
+
+        let uri = URI(url);
+        const domain = uri.domain();
+
+        // Remove tracking parameters
+        if (domain === 'twitter.com' || domain === 'x.com')
+        {
+            uri.removeQuery('t');
+        } 
+        else if (domain === 'youtube.com' || domain === 'youtu.be')
+        {
+            uri.removeQuery('si');
+        }
+
+        // Replace domain with its embed-friendly version (if it has one)
+        if (DOMAIN_MAPPING.hasOwnProperty(domain))
+        {
+            uri.domain(DOMAIN_MAPPING[domain]);
+        }
+
+        // Only repost if a URL has actually changed
+        if (!uri.equals(url))
+        {
+            repostMessage = true;
+        }
+        return uri.toString();
+    })
+
     if (repostMessage)
     {
         let guild = client.guilds.cache.get(message.guildId);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "discord.js": "^14.15.2",
         "dotenv": "^16.4.5",
-        "twitter-api-sdk": "^1.2.1"
+        "twitter-api-sdk": "^1.2.1",
+        "urijs": "^1.19.11"
       }
     },
     "node_modules/@discordjs/builders": {
@@ -326,6 +327,12 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "discord.js": "^14.15.2",
     "dotenv": "^16.4.5",
-    "twitter-api-sdk": "^1.2.1"
+    "twitter-api-sdk": "^1.2.1",
+    "urijs": "^1.19.11"
   }
 }


### PR DESCRIPTION
Now supports replacing multiple URLs in the same message. Also ignores replacing URLs that are wrapped in Discord's non-embed syntax since they don't need to be replaced with an embed-friendly version. This prevents the bot from deleting a user's message even if it only contains non-embedding links.